### PR TITLE
Use react-listener-provider if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 dist/bundle.js
+.idea/

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-perimeter-demo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A demo application using react-perimeter",
   "main": "index.js",
   "license": "MIT",
@@ -21,6 +21,7 @@
     "react-router-dom": "^4.0.0",
     "react-spinner": "^0.2.6",
     "styled-components": "^1.4.4",
-    "webpack-dev-server": "^2.4.2"
+    "webpack-dev-server": "^2.4.2",
+    "react-listener-provider": "^0.1.2"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-perimeter-demo",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "A demo application using react-perimeter",
   "main": "index.js",
   "license": "MIT",

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,6 +5,7 @@ import {
   Route,
   Link
 } from "react-router-dom";
+import ReactListenerProvider from 'react-listener-provider';
 import Home from "./routes/home";
 import About from "./routes/about";
 import Topics from "./routes/topics";
@@ -45,31 +46,33 @@ class App extends Component {
 
   render() {
     return (
-      <Router>
-        <div>
-          <ul>
-             <li>
-              <PreloadLink to="/" preload={Home} boundry={100}>
-                Home
-              </PreloadLink>
-            </li>
-            <li>
-              <PreloadLink to="/about" preload={About} boundry={100}>
-                About
-              </PreloadLink>
-            </li>
-            <li>
-              <PreloadLink to="/topics" preload={Topics} boundry={100}>
-                Topics
-              </PreloadLink>
-            </li>
-          </ul>
-          <hr />
-          <Route exact path="/" component={Home} />
-          <Route path="/about" component={About} />
-          <Route path="/topics" component={Topics} />
-        </div>
-      </Router>
+      <ReactListenerProvider>
+        <Router>
+          <div>
+            <ul>
+              <li>
+                <PreloadLink to="/" preload={Home} boundry={100}>
+                  Home
+                </PreloadLink>
+              </li>
+              <li>
+                <PreloadLink to="/about" preload={About} boundry={100}>
+                  About
+                </PreloadLink>
+              </li>
+              <li>
+                <PreloadLink to="/topics" preload={Topics} boundry={100}>
+                  Topics
+                </PreloadLink>
+              </li>
+            </ul>
+            <hr />
+            <Route exact path="/" component={Home} />
+            <Route path="/about" component={About} />
+            <Route path="/topics" component={Topics} />
+          </div>
+        </Router>
+      </ReactListenerProvider>
     );
   }
 }

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2502,6 +2502,10 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react-listener-provider@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/react-listener-provider/-/react-listener-provider-0.1.2.tgz#40338f198800f8991a8d9284f5617dffe51aebc1"
+
 react-loadable@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-3.0.1.tgz#d285d0f32680fef3cf7c1fd8853206415f824ad8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-perimeter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -27,5 +27,8 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
+  },
+  "optionalDependencies": {
+    "react-listener-provider": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-perimeter",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,13 @@ export default class Perimeter extends Component {
     mapListeners: React.PropTypes.func
   }
 
+  static contextTypes = {
+    listener: React.PropTypes.shape({
+      add: React.PropTypes.func.isRequired,
+      remove: React.PropTypes.func.isRequired
+    })
+  }
+
   /**
    * When the component mounts we calculate the ClientRect
    * for the target node and attach event listeners for:
@@ -59,11 +66,17 @@ export default class Perimeter extends Component {
    */
   componentDidMount() {
     const { handleMouseMove, handleResize, node } = this;
+    const { listener } = this.context;
     if (node) {
       this.bounds = node.getBoundingClientRect();
       this.initialOffset = window.pageYOffset;
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('resize', handleResize);
+      if(listener) {
+        listener.add('mousemove', handleMouseMove);
+        listener.add('resize', handleResize);
+      } else {
+        window.addEventListener('mousemove', handleMouseMove);
+        window.addEventListener('resize', handleResize);
+      }
       this.listening = true;
     }
   }
@@ -84,8 +97,14 @@ export default class Perimeter extends Component {
    * if the `once` prop is set to `true`
    */
   removeEventListeners() {
-    window.removeEventListener('mousemove', this.handleMouseMove);
-    window.removeEventListener('resize', this.handleResize);
+    const { listener } = this.context;
+    if(listener){
+      listener.remove('mousemove', handleMouseMove);
+      listener.remove('resize', handleResize);
+    } else {
+      window.removeEventListener('mousemove', this.handleMouseMove);
+      window.removeEventListener('resize', this.handleResize);
+    }
     this.listening = false;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export default class Perimeter extends Component {
     if (node) {
       this.bounds = node.getBoundingClientRect();
       this.initialOffset = window.pageYOffset;
-      if(listener) {
+      if( listener ) {
         listener.add('mousemove', handleMouseMove);
         listener.add('resize', handleResize);
       } else {
@@ -98,7 +98,7 @@ export default class Perimeter extends Component {
    */
   removeEventListeners() {
     const { listener } = this.context;
-    if(listener){
+    if( listener ){
       listener.remove('mousemove', handleMouseMove);
       listener.remove('resize', handleResize);
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
-
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -775,10 +771,6 @@ convert-source-map@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -839,12 +831,6 @@ electron-to-chromium@^1.2.5, electron-to-chromium@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.7.tgz#4f748061407e478c76256d04496972b71f647407"
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
-
 escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -878,18 +864,6 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
-
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1067,10 +1041,6 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@~0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1152,10 +1122,6 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
-is-stream@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -1169,13 +1135,6 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1244,7 +1203,7 @@ lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1309,13 +1268,6 @@ ms@0.7.2:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
-
-node-fetch@^1.0.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.33"
@@ -1426,12 +1378,6 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-promise@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  dependencies:
-    asap "~2.0.3"
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -1456,21 +1402,9 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
-  dependencies:
-    fbjs "^0.8.1"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
-  dependencies:
-    fbjs "^0.8.4"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+react-listener-provider@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/react-listener-provider/-/react-listener-provider-0.1.2.tgz#40338f198800f8991a8d9284f5617dffe51aebc1"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2:
   version "2.2.6"
@@ -1615,10 +1549,6 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -1733,10 +1663,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-ua-parser-js@^0.7.9:
-  version "0.7.12"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
-
 uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
@@ -1764,10 +1690,6 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 wide-align@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
As mentioned in #1 I went ahead and moved the MouseMoveProvider idea into its own package [react-listener-provider](https://github.com/jnsdls/react-listener-provider).

In this PR I'm using that to optionally provide global event listeners. (check `/demo`)

We should probably update the docs to reflect the ability to add `react-listener-provider`?