### PR TITLE
Upgrade react-listener-provider optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "react-dom": "^15.4.2"
   },
   "optionalDependencies": {
-    "react-listener-provider": "^0.1.2"
+    "react-listener-provider": "^0.2.0"
   }
 }


### PR DESCRIPTION
v0.2.0 of react-listener-provider removes usage of PropTypes from the react package and instead adds "prop-types" as a peerDependency.